### PR TITLE
#6 Add file download capability from the web

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/setup-msbuild@v4
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
@@ -35,7 +35,7 @@ jobs:
 
     # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
     - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1
+      uses: microsoft/setup-msbuild@v2
 
     - name: Install dependencies
       run: dotnet restore

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -35,7 +35,7 @@ jobs:
 
     # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
     - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v2
+      uses: microsoft/setup-msbuild@v1
 
     - name: Install dependencies
       run: dotnet restore

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Execute unit tests
       #run: dotnet test --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
       env:
-        API_KEY: ${{ secrets.VTAPIKEY }}
+        VTAPIKEY: ${{ secrets.VTAPIKEY }}
         DOTNET_CLI_TELEMETRY_OPTOUT: 1
       run: dotnet test --no-build --verbosity normal
 

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -23,19 +23,19 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/setup-msbuild@v4
       with:
         fetch-depth: 0
 
     # Install the .NET Core workload
     - name: Install .NET Core
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 8.0
 
     # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
     - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1
+      uses: microsoft/setup-msbuild@v2
 
     - name: Install dependencies
       run: dotnet restore

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -46,7 +46,10 @@ jobs:
 
     - name: Execute unit tests
       #run: dotnet test --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
-      run: dotnet test --no-build --verbosity normal
       env:
+        API_KEY: ${{ secrets.VTAPIKEY }}
         DOTNET_CLI_TELEMETRY_OPTOUT: 1
+      run: dotnet test --no-build --verbosity normal
+
+        
 

--- a/LauncherTests/LauncherTests.cs
+++ b/LauncherTests/LauncherTests.cs
@@ -1,10 +1,9 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Ntools;
 using System;
 using System.Diagnostics;
 using System.IO;
 
-namespace Launcher.Tests
+namespace Ntools.Tests
 {
     [TestClass]
     public class LauncherTests

--- a/LauncherTests/NFileTests.cs
+++ b/LauncherTests/NFileTests.cs
@@ -1,11 +1,9 @@
-﻿using Ntools;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
-using System.IO.Pipes;
 
 namespace Ntools.Tests
 {
@@ -102,13 +100,13 @@ namespace Ntools.Tests
         }
 
         [TestMethod()]
-        public async Task DownloadFileInvalidDownloadedFienameExceptionTestAsync()
+        public async Task DownloadFileInvalidDownloadedFilenameExceptionTestAsync()
         {
             // Arrange
             var expectedFail = new Dictionary<Uri, string>
             {
                 { new("https://desktop.docker.com/win/main/amd64/Docker%20Desktop%20Installer.exe"), "Docker.Desk>top.Installer.exe" },  //Invalid download filename: exception
-                { new("https://desktop.docker.com/win/main/amd64/Docker%20Desktop%20Installer2.exe"), "c:\\temp\\Docker.Desk>top.Installer.exe" },  //Invalid download filename: exception
+                { new("https://github.com/naz-hage/ntools/releases/download/1.3.0/1.3.0.zip"), "c:\\temp\\Docker.Desk>top.Installer.exe" },  //Invalid download filename: exception
                 { new("https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"), null },  //Invalid download filename: exception
             };
 
@@ -116,6 +114,8 @@ namespace Ntools.Tests
 
             foreach (var item in expectedFail)
             {
+                Console.WriteLine($"Uri: {item.Key}");
+                Console.WriteLine($"Downloaded file: {item.Value}");
                 // Act and Assert
                 await Assert.ThrowsExceptionAsync<ArgumentException>(async () => await httpClient.DownloadAsync(item.Key, item.Value));
             }
@@ -174,8 +174,8 @@ namespace Ntools.Tests
 
             // download file with not allowed extension
 
-            webDownloadFile = new("https://dist.nuget.org/win-x86-commandline/latest/nuget.zip");
-            downloadedFile = "nuget.zip";
+            webDownloadFile = new("https://dist.nuget.org/win-x86-commandline/latest/nuget.exe");
+            downloadedFile = "nuget.exe";
 
             // setup file name to download to temp folder because devtools is protected
             downloadedFile = Path.Combine(Path.GetTempPath(), Path.GetFileName(downloadedFile));
@@ -183,11 +183,13 @@ namespace Ntools.Tests
             {
                 File.Delete(downloadedFile);
             }
+            Nfile.SetAllowedExtensions(new List<string>());
 
             // Act
             try
             {
                 result = await httpClient.DownloadAsync(webDownloadFile, downloadedFile);
+                Console.WriteLine($"Download Response:\n {result.GetFirstOutput()}");
             }
             catch (Exception ex)
             {

--- a/LauncherTests/NFileTests.cs
+++ b/LauncherTests/NFileTests.cs
@@ -1,0 +1,123 @@
+﻿using Ntools;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.IO.Pipes;
+
+namespace Ntools.Tests
+{
+    [TestClass()]
+    public class NFileTests
+    {
+        [TestMethod()]
+        public async Task DownloadAsyncTest()
+        {
+            // Arrange
+            var httpClient = new HttpClient();
+            Uri webDownloadFile = new("https://dist.nuget.org/win-x86-commandline/latest/nuget.exe");
+            string downloadedFile = "nuget.exe";
+
+            // setup file name to download to temp folder because devtools is protected
+            downloadedFile = Path.Combine(Path.GetTempPath(), Path.GetFileName(downloadedFile));
+            if (File.Exists(downloadedFile))
+            {
+                File.Delete(downloadedFile);
+            }
+
+            // Act
+            var result = await httpClient.DownloadAsync(webDownloadFile, downloadedFile);
+
+            // Assert
+            Assert.IsTrue(File.Exists(downloadedFile));
+
+            Console.WriteLine($"File size: {result.FileSize}");
+            Console.WriteLine($"File is signed: {result.DigitallySigned}");
+            result.DisplayCertificate();
+
+            Assert.IsTrue(result.IsSuccess());
+            Assert.IsTrue(result.GetFirstOutput().Contains("Success"));
+        }
+
+        [TestMethod()]
+        public async Task DownloadFileTaskAsyncValidateParametersTestAsync()
+        {
+            // Arrange
+            var expectedFail = new Dictionary<Uri, string>
+            {
+                {   new("https://desktop.docker.com/win/main/am@d64/Docker%20Desktop%20Installer.exe"),"Docker.Desktop.Installer.exe" },
+                {   new("http://desktop.docker.com/win/main/amd64/Docker%20Desktop%20Installer.exe"), "Docker.Desktop.Installer.exe" },
+                {   new("https://desktop.docker.com/win/main/amd64/Docker%20Desktop%20Installer.exe"), "Docker.Desk>top.Installer.exe" },
+            };
+
+            var httpClient = new HttpClient();
+
+            foreach (var item in expectedFail)
+            {
+                // setup file name to download to temp folder because devtools is protected
+                var fileName = Path.Combine(Path.GetTempPath(), Path.GetFileName(item.Value));
+                if (File.Exists(fileName))
+                {
+                    File.Delete(fileName);
+                }
+
+                // Act
+                var result = await httpClient.DownloadAsync(item.Key, fileName);
+
+
+                Console.WriteLine($"output: {result.GetFirstOutput()}");
+
+                // Assert
+                Assert.IsFalse(result.IsSuccess());
+            }
+        }
+
+        [TestMethod()]
+        public async Task GetFileSizeAsyncTest()
+        {
+            // Arrange
+            var httpClient = new HttpClient();
+            Uri webDownloadFile = new("https://dist.nuget.org/win-x86-commandline/latest/nuget.exe");
+            string downloadedFile = "nuget.exe";
+
+            // setup file name to download to temp folder because devtools is protected
+            downloadedFile = Path.Combine(Path.GetTempPath(), Path.GetFileName(downloadedFile));
+            if (File.Exists(downloadedFile))
+            {
+                File.Delete(downloadedFile);
+            }
+
+            // Act
+            var result = await httpClient.GetFileSizeAsync(webDownloadFile.ToString());
+            Console.WriteLine($"File size: {result}");
+
+            // Assert
+            Assert.IsTrue(result > 0);
+        }
+
+        [TestMethod()]
+        public async Task UriExistsAsyncTest()
+        {
+            // Arrange
+            var httpClient = new HttpClient();
+            Uri webDownloadFile = new("https://dist.nuget.org/win-x86-commandline/latest/nuget.exe");
+            string downloadedFile = "nuget.exe";
+
+            // setup file name to download to temp folder because devtools is protected
+            downloadedFile = Path.Combine(Path.GetTempPath(), Path.GetFileName(downloadedFile));
+            if (File.Exists(downloadedFile))
+            {
+                File.Delete(downloadedFile);
+            }
+
+            // Act
+            var result = await httpClient.UriExistsAsync(webDownloadFile.ToString());
+            Console.WriteLine($"Uri Exist: {result}");
+
+            // Assert
+            Assert.IsTrue(result);
+        }
+    }
+}

--- a/LauncherTests/ResultDownloadTests.cs
+++ b/LauncherTests/ResultDownloadTests.cs
@@ -19,7 +19,7 @@ namespace Ntools.Tests
             var uri = new Uri("http://localhost");
 
             // Act
-            var resultDownload = new ResultDownload(fileName, uri);
+            var resultDownload = new ResultDownload(uri, fileName);
 
             // Assert
             Assert.AreEqual(fileName, resultDownload.FileName);

--- a/LauncherTests/ResultDownloadTests.cs
+++ b/LauncherTests/ResultDownloadTests.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Ntools;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Ntools.Tests
+{
+    [TestClass()]
+    public class ResultDownloadTests
+    {
+        [TestMethod()]
+        public void ResultDownloadTest()
+        {
+            // Arrange
+            string fileName = "test.txt";
+            var uri = new Uri("http://localhost");
+
+            // Act
+            var resultDownload = new ResultDownload(fileName, uri);
+
+            // Assert
+            Assert.AreEqual(fileName, resultDownload.FileName);
+            Assert.AreEqual(uri, resultDownload.Uri);
+            Assert.IsFalse(resultDownload.DigitallySigned);
+            Assert.AreEqual(0, resultDownload.FileSize);
+            Assert.IsNull(resultDownload.X509Certificate2);
+            Assert.AreEqual(int.MaxValue, resultDownload.Code);
+            Assert.AreEqual(0, resultDownload.Output.Count);
+        }
+    }
+}

--- a/LauncherTests/ResultHelperTests.cs
+++ b/LauncherTests/ResultHelperTests.cs
@@ -1,8 +1,6 @@
-﻿using Launcher;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Ntools;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Launcher.Tests
+namespace Ntools.Tests
 {
     [TestClass()]
     public class ResultHelperTests

--- a/LauncherTests/ShellUtilityTests.cs
+++ b/LauncherTests/ShellUtilityTests.cs
@@ -1,35 +1,114 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Ntools;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Ntools.Tests
 {
     [TestClass()]
     public class ShellUtilityTests
     {
-        [TestMethod,Ignore]
+        [TestMethod]
         public void GetFullPathOfFileTest()
         {
             // Arrange
-            var file = "git.exe";
-            var expected = @"C:\Program Files\git\cmd\git.exe";
-            // on GitHub Actions, git.exe is 
-            var githubActions = Environment.GetEnvironmentVariable("GITHUB_ACTIONS", EnvironmentVariableTarget.User);
-            if (githubActions != null && githubActions.Equals("true", StringComparison.OrdinalIgnoreCase))
-            {
-                expected = @"C:\Program Files\Git\bin\git.exe"; //C:\Program Files\Git\bin\git.exe
-            }
+            var file = "xcopy.exe";
+            var expected = @"C:\Windows\System32\xcopy.exe";
             
             // Act
             var actual = ShellUtility.GetFullPathOfFile(file);
+            if (!string.IsNullOrEmpty(actual))
+            {
+                Console.WriteLine($"Full path of {file}: {actual}");
+            }
 
             // Assert
             // compare expected and actual strings not case sensitive
             Assert.AreEqual(expected, actual, true);
         }
+
+        [TestMethod]
+        public void GetFullPathOfFileEmptyTest()
+        {
+            // Arrange for empty file
+            var file = string.Empty;
+            var expected = "";
+
+            // Act
+            var actual = ShellUtility.GetFullPathOfFile(file);
+            if (!string.IsNullOrEmpty(actual))
+            {
+                Console.WriteLine($"Full path of {file}: {actual}");
+            }
+
+            // Assert
+            // compare expected and actual strings not case sensitive
+            Assert.AreEqual(expected, actual, true);
+
+        }
+
+        [TestMethod]
+        public void GetFullPathOfFileNullTest()
+        {
+            // Arrange for null file
+            string file = null;
+            var expected = "";
+
+            // Act
+            var actual = ShellUtility.GetFullPathOfFile(file);
+            if (!string.IsNullOrEmpty(actual))
+            {
+                Console.WriteLine($"Full path of {file}: {actual}");
+            }
+
+            // Assert
+            // compare expected and actual strings not case sensitive
+            Assert.AreEqual(expected, actual, true);
+
+
+        }
+
+        [TestMethod]
+        public void GetFullPathOfFileUnknownTest()
+        {
+
+            // Arrange for file that is unknown
+            var file = Guid.NewGuid().ToString();
+            var expected = "";
+
+            // Act
+            var actual = ShellUtility.GetFullPathOfFile(file);
+            if (!string.IsNullOrEmpty(actual))
+            {
+                Console.WriteLine($"Full path of {file}: {actual}");
+            }
+
+            // Assert
+            // compare expected and actual strings not case sensitive
+            Assert.AreEqual(expected, actual, true);
+
+            // Assert
+            // compare expected and actual strings not case sensitive
+            Assert.AreEqual(expected, actual, true);
+
+
+        }
+
+        [TestMethod]
+        public void GetFullPathOfFileInvalidTest()
+        {
+            // Arrange for file with invalid characters
+            var file = ":this";
+            var expected = "";
+
+            // Act
+            var actual = ShellUtility.GetFullPathOfFile(file);
+            if (!string.IsNullOrEmpty(actual))
+            {
+                Console.WriteLine($"Full path of {file}: {actual}");
+            }
+
+            // Assert
+            // compare expected and actual strings not case sensitive
+            Assert.AreEqual(expected, actual, true);
+        }   
     }
 }

--- a/LauncherTests/SignatureVerifierTests.cs
+++ b/LauncherTests/SignatureVerifierTests.cs
@@ -1,11 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Ntools;
 using System;
-using System.Diagnostics;
-using System.IO;
-using System.Security.Cryptography.X509Certificates;
 
-namespace Launcher.Tests
+namespace Ntools.Tests
 {
     [TestClass()]
     public class SignatureVerifierTests

--- a/LauncherTests/SignatureVerifierTests.cs
+++ b/LauncherTests/SignatureVerifierTests.cs
@@ -35,33 +35,7 @@ namespace Launcher.Tests
             // Assert
             Assert.IsTrue(result);
 
-            DisplayCertificate(fileStream.Name);
-        }
-
-        public static void DisplayCertificate(string fileName)
-        {
-            if (string.IsNullOrEmpty(fileName))
-            {
-                throw new ArgumentException("File name cannot be null or empty.", nameof(fileName));
-            }
-
-            if (!File.Exists(fileName))
-            {
-                throw new ArgumentException("File does not exist.", nameof(fileName));
-            }
-
-            // Create an X509Certificate2 object to represent the certificate of the signed file.
-            var cert = new X509Certificate2(fileName);
-
-            // Display the properties of the certificate.
-            Console.WriteLine($"SignatureAlgorithm: {cert.SignatureAlgorithm.FriendlyName}");
-            Console.WriteLine($"Subject: {cert.Subject}");
-            Console.WriteLine($"Issuer: {cert.Issuer}");
-            Console.WriteLine($"Version: {cert.Version}");
-            Console.WriteLine($"Valid From: {cert.NotBefore}");
-            Console.WriteLine($"Valid To: {cert.NotAfter}");
-            Console.WriteLine($"Serial Number: {cert.SerialNumber}");
-            Console.WriteLine($"Thumbprint: {cert.Thumbprint}");
+            SignatureVerifier.DisplayCertificate(fileStream.Name);
         }
     }
 }

--- a/LauncherTests/VirusTotalCheckerTests.cs
+++ b/LauncherTests/VirusTotalCheckerTests.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Tests
+{
+    [TestClass()]
+    public class VirusTotalCheckerTests
+    {
+        [TestMethod(),Ignore]
+        public void CheckFileAsyncTest()
+        {
+            string key = "fa7d716fa86ad82f76583c3b2b062c60b90b2975ea57559fcc713046f281ce2a"; // Replace with your own key
+            // Arrange
+            var checker = new VirusTotalChecker();
+            var file = @"c:\temp\1.2.57.zip";
+
+            // Act
+            var result = checker.CheckFileAsync(file, key).Result;
+
+
+            // Assert
+            Assert.IsNotNull(result);
+
+            // Get the result from the VirusTotal API
+            Assert.IsTrue(checker.VirusFree);
+        }
+    }
+}

--- a/LauncherTests/VirusTotalCheckerTests.cs
+++ b/LauncherTests/VirusTotalCheckerTests.cs
@@ -8,19 +8,21 @@ namespace Ntools.Tests
     [TestClass()]
     public class VirusTotalCheckerTests
     {
+        private const string ApiKey = "VTAPIKEY";
+
         [TestMethod]
         public async Task CheckFileAsyncTestAsync()
         {
             // Arrange: Get VT key and download a file to check
-            var key = Environment.GetEnvironmentVariable("VTAPIKEY");
-            Assert.IsNotNull(key);
+            var key = Environment.GetEnvironmentVariable(ApiKey);
+            Assert.IsNotNull(key, "key is null");
             
             var file = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe";
             Nfile.SetTrustedHosts(["dist.nuget.org"]);
             Nfile.SetAllowedExtensions([".exe"]);
             var downloadedFile = Path.Combine(Environment.GetEnvironmentVariable("TEMP"), "nuget.exe");
             await Nfile.DownloadAsync(file, downloadedFile);
-            Assert.IsTrue(File.Exists(downloadedFile));
+            Assert.IsTrue(File.Exists(downloadedFile), $"{downloadedFile} did not download");
 
             var checker = new VirusTotalChecker();  
 
@@ -28,10 +30,10 @@ namespace Ntools.Tests
             var result = checker.CheckFileAsync(downloadedFile, key).Result;
 
             // Assert
-            Assert.IsNotNull(result);
+            Assert.IsNotNull(result, "result is null");
 
             // Get the result from the VirusTotal API and assert the file is virus free
-            Assert.IsTrue(checker.VirusFree);
+            Assert.IsTrue(checker.VirusFree, $"{downloadedFile} is not virus free");
         }
     }
 }

--- a/LauncherTests/VirusTotalCheckerTests.cs
+++ b/LauncherTests/VirusTotalCheckerTests.cs
@@ -1,31 +1,36 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System.IO;
 using System.Threading.Tasks;
 
-namespace Tests
+namespace Ntools.Tests
 {
     [TestClass()]
     public class VirusTotalCheckerTests
     {
-        [TestMethod(),Ignore]
-        public void CheckFileAsyncTest()
+        [TestMethod]
+        public async Task CheckFileAsyncTestAsync()
         {
-            string key = "fa7d716fa86ad82f76583c3b2b062c60b90b2975ea57559fcc713046f281ce2a"; // Replace with your own key
-            // Arrange
-            var checker = new VirusTotalChecker();
-            var file = @"c:\temp\1.2.57.zip";
+            // Arrange: Get VT key and download a file to check
+            var key = Environment.GetEnvironmentVariable("VTAPIKEY");
+            Assert.IsNotNull(key);
+            
+            var file = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe";
+            Nfile.SetTrustedHosts(["dist.nuget.org"]);
+            Nfile.SetAllowedExtensions([".exe"]);
+            var downloadedFile = Path.Combine(Environment.GetEnvironmentVariable("TEMP"), "nuget.exe");
+            await Nfile.DownloadAsync(file, downloadedFile);
+            Assert.IsTrue(File.Exists(downloadedFile));
+
+            var checker = new VirusTotalChecker();  
 
             // Act
-            var result = checker.CheckFileAsync(file, key).Result;
-
+            var result = checker.CheckFileAsync(downloadedFile, key).Result;
 
             // Assert
             Assert.IsNotNull(result);
 
-            // Get the result from the VirusTotal API
+            // Get the result from the VirusTotal API and assert the file is virus free
             Assert.IsTrue(checker.VirusFree);
         }
     }

--- a/launcher/Launcher.csproj
+++ b/launcher/Launcher.csproj
@@ -42,6 +42,7 @@
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="8.0.0" />
     <PackageReference Include="System.Security.Cryptography.X509Certificates" Version="4.3.2" />
     <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0" />
+    <PackageReference Include="System.Text.Json" Version="8.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/launcher/Nfile.cs
+++ b/launcher/Nfile.cs
@@ -1,0 +1,127 @@
+using System;
+using System.IO;
+using System.IO.Pipes;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Ntools
+{
+    public static class Nfile
+    {
+        public static async Task<ResultDownload> DownloadAsync(this HttpClient client, Uri uri, string fileName)
+        {
+            var resultDownload = new ResultDownload (fileName, uri);
+            try
+            {
+                if (!ValidUri(resultDownload.Uri.ToString())) throw new ArgumentException("Invalid uri", nameof(resultDownload.Uri));
+
+                if (string.IsNullOrEmpty(resultDownload.FileName)) throw new ArgumentException("Invalid file name.", nameof(resultDownload.FileName));
+
+                if (!Path.IsPathRooted(resultDownload.FileName)) throw new ArgumentException("Invalid file name. Must be a valid full path.", nameof(resultDownload.FileName));
+
+                // Check if fileName contains invalid characters
+                var invalidChars = Path.GetInvalidFileNameChars();
+
+                if (Path.GetFileName(resultDownload.FileName).IndexOfAny(invalidChars) >= 0) throw new ArgumentException("Invalid file name. Contains invalid characters.", nameof(resultDownload.FileName));
+
+                if (File.Exists(resultDownload.FileName)) File.Delete(resultDownload.FileName);
+
+                var response = await client.GetAsync(resultDownload.Uri);
+                if (!response.IsSuccessStatusCode) throw new FileNotFoundException($"'{resultDownload.Uri}' not found. status: {response.StatusCode}", nameof(resultDownload.Uri));
+
+                using (var s = await client.GetStreamAsync(resultDownload.Uri))
+                using (var fs = new FileStream(resultDownload.FileName, FileMode.Create))
+                {
+                    await s.CopyToAsync(fs);
+                }
+                resultDownload.Success();
+                
+            }
+            catch (ArgumentNullException ex)
+            {
+                resultDownload.Fail(ex.Message);
+            }
+            catch (ArgumentException ex)
+            {
+                resultDownload.Fail(ex.Message);
+            }
+            catch (Exception ex)
+            {
+                resultDownload.Fail(ex.Message);
+            }
+            finally
+            {
+                if (resultDownload.IsSuccess())
+                {
+                    // Check if file got downnloaed and do any cleanup here
+                    if (!File.Exists(resultDownload.FileName)) resultDownload.Fail($"File {resultDownload.FileName} does not exist.");
+
+                    //Set digital signature and file size
+                    resultDownload.SetFileSigned();
+                    resultDownload.SetFileSize();
+                }
+            }
+
+            return resultDownload;
+        }
+
+        // Add a method to check if a Uri exists
+        public static async Task<bool> UriExistsAsync(this HttpClient client, string uri)
+        {
+            if (!ValidUri(uri)) throw new ArgumentException("Invalid uri", nameof(uri));
+
+            try
+            {
+                var response = await client.GetAsync(uri);
+                return response.IsSuccessStatusCode;
+            }
+            catch (HttpRequestException)
+            {
+                // pass through exception to caller
+                throw;
+            }
+        }
+
+        // Add a method to get the file size of a Uri
+        public static async Task<long> GetFileSizeAsync(this HttpClient client, string uri)
+        {
+            if (!ValidUri(uri.ToString())) throw new ArgumentException("Invalid uri", nameof(Uri));
+
+            try
+            {
+                var response = await client.GetAsync(uri);
+                return response.Content.Headers.ContentLength ?? 0;
+            }
+            catch (HttpRequestException)
+            {
+                // pass through exception to caller
+                throw;
+            }
+        }
+
+        public static async Task<bool> UriExistsAsync(string uri)
+        {
+            using (var client = new HttpClient())
+            {
+                try
+                {
+                    var response = await client.GetAsync(uri);
+                    return response.IsSuccessStatusCode;
+                }
+                catch (HttpRequestException)
+                {
+                    return false;
+                }
+            }
+        }
+
+        public static bool ValidUri(string uri)
+        {
+            if (uri == null) throw new ArgumentNullException(nameof(uri));
+
+            bool result = Uri.TryCreate(uri, UriKind.Absolute, out Uri uriResult)
+                        && uriResult.Scheme == Uri.UriSchemeHttps;
+            return result;
+        }
+    }
+}

--- a/launcher/Nfile.cs
+++ b/launcher/Nfile.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.IO.Pipes;
 using System.Net;
 using System.Net.Http;
 using System.Net.Security;

--- a/launcher/README.md
+++ b/launcher/README.md
@@ -4,12 +4,15 @@ Ntools is a .NET namespace that provides various utilities for launching process
 
 - **Launcher:** Provides methods to launch a process and wait for it to complete.
     - **LockVerifyStart:** A methods that locks file and verify that a file is digitally signed before launching.
-    - **LockStart:** A method that locks procees before launching.
+    - **LockStart:** A method that locks process before launching.
     - **LaunchInThread:** A method that launches a process in a separate thread.
 - **ResultHelper:** Provides a helper class and methods to retrieve the result `Code` and `Output` of the launched executable.
 - **CurrentProcess:** Provides a method to determine if the current process is elevated.
 - **ShellUtility:** A helper class that executes shell commands.
     - **GetFullPathOfFile:** A method that retrieves the full path of a file from the Path environment variable.
+- **Download:** A class that downloads file from the web.
+    - **File:** A method that downloads a file from the web and save to a local drive.
+    - **SignedFile:** A method that downloads a file and expects file to be digitally signed. If files is signed, method succeeds.  Otherwise, file is deleted.
 
 
 ## Installation

--- a/launcher/ResultDownload.cs
+++ b/launcher/ResultDownload.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+
+namespace Ntools
+{
+    public class ResultDownload : ResultHelper
+    {
+        public string FileName { get; } = string.Empty;
+        public Uri Uri { get; } = new Uri("http://localhost");
+
+        public bool DigitallySigned { get; private set; }
+
+        public long FileSize { get; private set; }
+
+        public X509Certificate2 X509Certificate2 { get; private set; }
+
+        public ResultDownload(string fileName, Uri uri)
+        {
+            New();
+            FileName = fileName;
+            Uri = uri;
+            DigitallySigned = false;
+        }
+
+        public void Success()
+        {
+            Code = 0;
+            Output.Add("Success");
+        }
+
+        public void Fail(string message)
+        {
+            Code = -1;
+            Output.Add(message);
+        }
+
+        public void SetFileSize()
+        {
+            try
+            {
+                HttpClient httpClient = new HttpClient();
+                FileSize = Task.Run(async () => await httpClient.GetFileSizeAsync(Uri.ToString())).Result;
+            }
+            catch (Exception)
+            {
+                FileSize = 0;
+            }
+        }
+
+        public void SetFileSigned()
+        {
+            DigitallySigned = SignatureVerifier.VerifyDigitalSignature(FileName);
+            if (DigitallySigned)
+            {
+                X509Certificate2 = new X509Certificate2(FileName);
+            }
+        }
+
+        public void DisplayCertificate()
+        {
+            if (DigitallySigned)
+            {
+
+                try
+                {
+                    SignatureVerifier.DisplayCertificate(FileName);
+                }
+                catch (CryptographicException ex)
+                {
+                    // display the error message
+                    Console.WriteLine($"CryptographicException: {ex.Message}");
+                    DigitallySigned = false;
+                }
+            }
+            else
+            {
+                Console.WriteLine($"File `{FileName}` is not digitally signed.");
+            }
+        }
+    }
+}

--- a/launcher/ResultDownload.cs
+++ b/launcher/ResultDownload.cs
@@ -18,7 +18,7 @@ namespace Ntools
 
         public X509Certificate2 X509Certificate2 { get; private set; }
 
-        public ResultDownload(string fileName, Uri uri)
+        public ResultDownload(Uri uri, string fileName)
         {
             New();
             FileName = fileName;
@@ -41,8 +41,7 @@ namespace Ntools
         {
             try
             {
-                HttpClient httpClient = new HttpClient();
-                FileSize = Task.Run(async () => await httpClient.GetFileSizeAsync(Uri.ToString())).Result;
+                FileSize = Task.Run(async () => await Nfile.GetFileSizeAsync(Uri.ToString())).Result;
             }
             catch (Exception)
             {

--- a/launcher/ResultDownload.cs
+++ b/launcher/ResultDownload.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Net.Http;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
@@ -8,12 +9,12 @@ namespace Ntools
 {
     public class ResultDownload : ResultHelper
     {
-        public string FileName { get; } = string.Empty;
-        public Uri Uri { get; } = new Uri("http://localhost");
+        public string FileName { get; }
+        public Uri Uri { get; }
 
-        public bool DigitallySigned { get; private set; }
+        public bool DigitallySigned { get; private set; } = false;
 
-        public long FileSize { get; private set; }
+        public long FileSize { get; private set; } = 0;
 
         public X509Certificate2 X509Certificate2 { get; private set; }
 
@@ -22,7 +23,6 @@ namespace Ntools
             New();
             FileName = fileName;
             Uri = uri;
-            DigitallySigned = false;
         }
 
         public void Success()

--- a/launcher/ResultHelper.cs
+++ b/launcher/ResultHelper.cs
@@ -20,7 +20,7 @@ namespace Ntools
         public int Code { get; set; } = Exception;
 
         // The result output
-        public List<string> Output { get; set; } = new List<string>() { UndefinedMessage };
+        public List<string> Output { get; set; } = new List<string>();
 
         // Checks if the result is a success
         public bool IsSuccess()

--- a/launcher/ShellUtility.cs
+++ b/launcher/ShellUtility.cs
@@ -1,6 +1,8 @@
 ﻿using Ntools;
 using System;
 using System.Diagnostics;
+using System.Drawing;
+using System.IO;
 
 namespace Ntools
 {
@@ -12,8 +14,23 @@ namespace Ntools
         //   command: The command to search for the file
         // Returns:
         //   The full path of the file if found, otherwise an empty string
-        public static string GetFullPathOfFile(string command)
+        public static string GetFullPathOfFile(string command, bool versobe = false)
         {
+            if (string.IsNullOrEmpty(command)) return string.Empty;
+
+            // Don't accept invalid characters
+            //  < (less than)
+            //	> (greater than)
+            //	: (colon)
+            //	" (double quote)
+            //	/ (forward slash)
+            //	\ (backslash)
+            //	| (pipe)
+            //	? (question mark)
+            //	*(asterisk)
+            // return empty if command contains invalid characters for directory or file name
+            if (command.IndexOfAny(Path.GetInvalidPathChars()) >= 0) return string.Empty;
+
             var process = new Process()
             {
                 StartInfo = new ProcessStartInfo()
@@ -28,7 +45,12 @@ namespace Ntools
                     WindowStyle = ProcessWindowStyle.Hidden
                 }
             };
-            var result = process.LockStart(false);
+
+            var result = process.LockStart(versobe);
+            if (!result.IsSuccess())
+            {
+                return string.Empty;
+            }
 
             return result.GetFirstOutput();
         }

--- a/launcher/SignatureVerifier.cs
+++ b/launcher/SignatureVerifier.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.ComTypes;
 using System.Security.Cryptography.Pkcs;
 using System.Security.Cryptography.X509Certificates;
 
@@ -111,6 +112,34 @@ namespace Ntools
             Console.WriteLine("Valid From: " + certificate.NotBefore);
             Console.WriteLine("Valid To: " + certificate.NotAfter);
             Console.WriteLine("Thumbprint: " + certificate.Thumbprint);
+        }
+
+        // Display the properties of a Digital certificate
+        public static void DisplayCertificate(string fileName)
+        {
+            if (string.IsNullOrEmpty(fileName))
+            {
+                throw new ArgumentException("File name cannot be null or empty.", nameof(fileName));
+            }
+
+            if (!File.Exists(fileName))
+            {
+                throw new ArgumentException("File does not exist.", nameof(fileName));
+            }
+            // Create an X509Certificate2 object to represent the certificate of the signed file.
+            var cert = new X509Certificate2(fileName);
+
+            // Display the properties of the certificate.
+            Console.WriteLine($"Certificate Properties ");
+            Console.WriteLine($"---------------------- ");
+            Console.WriteLine($"SignatureAlgorithm: {cert.SignatureAlgorithm.FriendlyName}");
+            Console.WriteLine($"Subject: {cert.Subject}");
+            Console.WriteLine($"Issuer: {cert.Issuer}");
+            Console.WriteLine($"Version: {cert.Version}");
+            Console.WriteLine($"Valid From: {cert.NotBefore}");
+            Console.WriteLine($"Valid To: {cert.NotAfter}");
+            Console.WriteLine($"Serial Number: {cert.SerialNumber}");
+            Console.WriteLine($"Thumbprint: {cert.Thumbprint}");
         }
     }
 

--- a/launcher/VirusTotalChecker.cs
+++ b/launcher/VirusTotalChecker.cs
@@ -1,0 +1,154 @@
+﻿using System;
+using System.IO;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+public class VirusTotalChecker
+{
+    private static readonly HttpClient client = new HttpClient();
+    public bool VirusFree { get; private set; }
+
+    public async Task<string> CheckFileAsync(string filePath, string apiKey)
+    {
+        var url = "https://www.virustotal.com/api/v3/files";
+        var request = new HttpRequestMessage(HttpMethod.Post, url);
+
+        request.Headers.Add("x-apikey", apiKey);
+
+        var multiContent = new MultipartFormDataContent();
+        var fileBytes = File.ReadAllBytes(filePath);
+        var byteArrayContent = new ByteArrayContent(fileBytes);
+        byteArrayContent.Headers.Add("Content-Type", "application/octet-stream");
+        multiContent.Add(byteArrayContent, "file", Path.GetFileName(filePath));
+
+        request.Content = multiContent;
+
+        var response = await client.SendAsync(request);
+        var jsonResponse = await response.Content.ReadAsStringAsync();
+
+        var jsonDocument = JsonDocument.Parse(jsonResponse);
+        var root = jsonDocument.RootElement;
+        var analysisId = root.GetProperty("data").GetProperty("id").GetString();
+
+        // get the result from the VirusTotal API
+        jsonResponse = await AnalyzeFileAsync(analysisId, apiKey);
+
+        VirusFree = VirusDetected(jsonResponse);
+
+        return jsonResponse;
+    }
+
+    private async Task<string> GetScanResultsAsync(string analysisId, string apiKey)
+    {
+        var url = $"https://www.virustotal.com/api/v3/analyses/{analysisId}";
+        var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.Add("x-apikey", apiKey);
+
+        var response = await client.SendAsync(request);
+        var jsonResponse = await response.Content.ReadAsStringAsync();
+
+        return jsonResponse;
+    }
+
+    public async Task<string> WaitForScanResultsAsync(string analysisId, string apiKey)
+    {
+        string result;
+        do
+        {
+            await Task.Delay(TimeSpan.FromMinutes(1)); // Wait for 1 minute
+            result = await GetScanResultsAsync(analysisId, apiKey);
+        }
+        while (result.Contains("NotFoundError")); // Continue if the result is not found
+
+        return result;
+    }
+
+    public bool IsFileGood1(string jsonResponse)
+    {
+        var jsonDocument = JsonDocument.Parse(jsonResponse);
+        var root = jsonDocument.RootElement;
+        var attributes = root.GetProperty("data").GetProperty("attributes");
+
+        var status = attributes.GetProperty("status").GetString();
+
+        // If the analysis is not completed yet, we can't determine whether the file is good
+        if (status != "completed")
+        {
+            throw new InvalidOperationException("The analysis is not completed yet.");
+        }
+
+        var stats = attributes.GetProperty("stats");
+
+        var malicious = stats.GetProperty("malicious").GetInt32();
+        var suspicious = stats.GetProperty("suspicious").GetInt32();
+
+        // If any engine detected the file as malicious or suspicious, we consider the file as not good
+        return malicious == 0 && suspicious == 0;
+    }
+
+    public bool VirusDetected(string jsonResponse, bool ignoreGridinsoft = true)
+    {
+        var jsonDocument = JsonDocument.Parse(jsonResponse);
+        var root = jsonDocument.RootElement;
+        var attributes = root.GetProperty("data").GetProperty("attributes");
+
+        var status = attributes.GetProperty("status").GetString();
+
+        // If the analysis is not completed yet, we can't determine whether the file is good
+        if (status != "completed")
+        {
+            throw new InvalidOperationException("The analysis is not completed yet.");
+        }
+
+        var results = attributes.GetProperty("results");
+        var stats = attributes.GetProperty("stats");
+
+        var malicious = stats.GetProperty("malicious").GetInt32();
+        var suspicious = stats.GetProperty("suspicious").GetInt32();
+
+        if (ignoreGridinsoft)
+        {
+            // If Gridinsoft is the only one that detected the file as malicious, ignore it
+            if (malicious == 1 && results.TryGetProperty("Gridinsoft", out var gridinsoftResult))
+            {
+                var category = gridinsoftResult.GetProperty("category").GetString();
+                if (category == "malicious")
+                {
+                    malicious = 0;
+                }
+            }
+        }
+        // If any engine detected the file as malicious or suspicious, we consider the file as not good
+        return malicious == 0 && suspicious == 0;
+    }
+
+    public async Task<string> AnalyzeFileAsync(string analysisId, string apiKey)
+    {
+        string jsonResponse;
+        string status = "";
+
+
+        do
+        {
+            await Task.Delay(TimeSpan.FromMinutes(1)); // Wait for 1 minute
+
+            jsonResponse = await GetScanResultsAsync(analysisId, apiKey);
+
+            var jsonDocument = JsonDocument.Parse(jsonResponse);
+            var root = jsonDocument.RootElement;
+
+            // If the analysis is not found or not completed yet, continue waiting
+            if (jsonResponse.Contains("NotFoundError"))
+            {
+                continue;
+            }
+
+            status = root.GetProperty("data").GetProperty("attributes").GetProperty("status").GetString();
+
+        } while (status == "queued");
+
+        // Now the analysis should be completed, so we can interpret the results
+        return jsonResponse;
+    }
+}

--- a/ntools-launcher.sln
+++ b/ntools-launcher.sln
@@ -22,6 +22,15 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{975DD70F-DD7A-47B0-BCD1-2A2814EA3914}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ISSUE_TEMPLATE", "ISSUE_TEMPLATE", "{F58E0A42-C27D-4F91-B649-5991E477C42E}"
+	ProjectSection(SolutionItems) = preProject
+		.github\ISSUE_TEMPLATE\bug_report.md = .github\ISSUE_TEMPLATE\bug_report.md
+		.github\ISSUE_TEMPLATE\custom.md = .github\ISSUE_TEMPLATE\custom.md
+		.github\ISSUE_TEMPLATE\feature_request.md = .github\ISSUE_TEMPLATE\feature_request.md
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{A49F6E80-00BE-48DA-9902-B0606A41A210}"
 	ProjectSection(SolutionItems) = preProject
 		.github\workflows\dotnet-desktop.yml = .github\workflows\dotnet-desktop.yml
 	EndProjectSection
@@ -47,6 +56,10 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{F58E0A42-C27D-4F91-B649-5991E477C42E} = {975DD70F-DD7A-47B0-BCD1-2A2814EA3914}
+		{A49F6E80-00BE-48DA-9902-B0606A41A210} = {975DD70F-DD7A-47B0-BCD1-2A2814EA3914}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {78E5EED6-EE17-46FC-8046-AEB7486912C3}


### PR DESCRIPTION
The most significant changes include the addition of new test cases and methods, the removal and relocation of certain methods, and the correction of a typo in the README file.

1. The `ShellUtilityTests.cs` file was updated to include additional test cases for the `GetFullPathOfFile` method. These test cases now cover scenarios where the file is empty, null, unknown, and contains invalid characters. The `GetFullPathOfFileTest` method was also updated to test for a different file (`xcopy.exe` instead of `git.exe`).

2. The `SignatureVerifierTests.cs` file was updated to remove the `DisplayCertificate` method and instead call the `DisplayCertificate` method from the `SignatureVerifier` class.

3. The `README.md` file was updated to correct a typo and add information about the `Download` class and its methods.

4. The `ResultHelper.cs` file was updated to initialize the `Output` property as an empty list instead of a list containing `UndefinedMessage`.

5. The `ShellUtility.cs` file was updated to include additional checks in the `GetFullPathOfFile` method. It now checks if the command is null or empty and if it contains any invalid characters. If either of these checks fail, it returns an empty string. The method signature was also updated to include a `verbose` parameter.

6. The `SignatureVerifier.cs` file was updated to include the `DisplayCertificate` method that was removed from the `SignatureVerifierTests.cs` file. This method displays the properties of a digital certificate.

7. The `NFileTests.cs` file was added to include test cases for the `DownloadAsync`, `DownloadFileTaskAsyncValidateParameters`, `GetFileSizeAsync`, and `UriExistsAsync` methods.

8. The `Nfile.cs` file was added to include the `DownloadAsync`, `UriExistsAsync`, `GetFileSizeAsync`, and `ValidUri` methods. These methods are used to download a file, check if a URI exists, get the file size of a URI, and validate a URI, respectively.

9. The `ResultDownload.cs` file was added to include the `ResultDownload` class. This class extends the `ResultHelper` class and includes additional properties and methods related to downloading a file.