### PR TITLE
21-issue: Update target frameworks and package references

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Install .NET Core
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0
+        dotnet-version: 9.0
 
     - name: Setup MSBuild
       uses: microsoft/setup-msbuild@v2

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -50,11 +50,6 @@ jobs:
     - name: Setup MSBuild
       uses: microsoft/setup-msbuild@v2
 
-    - name: Install Visual Studio
-      uses: microsoft/setup-msbuild@v2
-      with:
-        vs-version: 17.12
-
     - name: Install ntools
       run: |
         cd ./DevSetup

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Install Visual Studio
       uses: microsoft/setup-msbuild@v2
       with:
-        vs-version: 17.6
+        vs-version: 17.12
 
     - name: Install ntools
       run: |

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -50,6 +50,11 @@ jobs:
     - name: Setup MSBuild
       uses: microsoft/setup-msbuild@v2
 
+    - name: Install Visual Studio
+      uses: microsoft/setup-msbuild@v2
+      with:
+        vs-version: 17.6
+
     - name: Install ntools
       run: |
         cd ./DevSetup

--- a/LauncherTest/LauncherTest.csproj
+++ b/LauncherTest/LauncherTest.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0-windows7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Version></Version>
     <AssemblyVersion></AssemblyVersion>
     <Authors>naz-hage</Authors>

--- a/LauncherTest/LauncherTest.csproj
+++ b/LauncherTest/LauncherTest.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows7.0</TargetFramework>
     <Version></Version>
     <AssemblyVersion></AssemblyVersion>
     <Authors>naz-hage</Authors>

--- a/LauncherTests/launcherTests.csproj
+++ b/LauncherTests/launcherTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Version></Version>
     <AssemblyVersion></AssemblyVersion>
@@ -26,8 +26,8 @@
 
   <ItemGroup>
  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
- <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
- <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
+ <PackageReference Include="MSTest.TestAdapter" Version="3.6.3" />
+ <PackageReference Include="MSTest.TestFramework" Version="3.6.3" />
  <PackageReference Include="coverlet.collector" Version="6.0.2">
     <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/docs/revisions/changelog.md
+++ b/docs/revisions/changelog.md
@@ -1,5 +1,7 @@
-### Version 1.6.0 - 07-may-24
+### Version 1.6.0 - 14-nov-24
 - [issue #14](https://github.com/naz-hage/ntools-launcher/issues/14) - Feature: Publish documentation using mkdocs
+- [issue #17](https://github.com/naz-hage/ntools-launcher/issues/14) - Bug:Microsoft Security Advisory CVE-2024-43485 | .NET Denial of Service Vulnerability
+- [issue #21](https://github.com/naz-hage/ntools-launcher/issues/21) - Feature: Update Target Frameworks to 9.0 and Package References
 
 
 ### Version 1.5.0 - 29-feb-24

--- a/launcher/Launcher.csproj
+++ b/launcher/Launcher.csproj
@@ -39,10 +39,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="8.0.1" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="9.0.0" />
     <PackageReference Include="System.Security.Cryptography.X509Certificates" Version="4.3.2" />
     <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0" />
-    <PackageReference Include="System.Text.Json" Version="8.0.5" />
+    <PackageReference Include="System.Text.Json" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/launcher/ntools-launcher.nuspec
+++ b/launcher/ntools-launcher.nuspec
@@ -14,9 +14,9 @@
     <tags></tags>
 	  <dependencies>
 		  <group targetFramework=".NETStandard2.0">
-			  <dependency id="System.Security.Principal.Windows" version="7.0.0" />
+			  <dependency id="System.Security.Principal.Windows" version="5.0.0" />
 			  <dependency id="System.Security.Cryptography.Pkcs" version="9.0.0" />
-			  <dependency id="System.Security.Cryptography.X509Certificates" version="7.0.0" />
+			  <dependency id="System.Security.Cryptography.X509Certificates" version="4.3.2" />
 		  </group>
 	  </dependencies>
   </metadata>

--- a/launcher/ntools-launcher.nuspec
+++ b/launcher/ntools-launcher.nuspec
@@ -12,13 +12,13 @@
     <copyright>2020-2024</copyright>
     <readme>README.md</readme>
     <tags></tags>
-    <dependencies>
-      <group targetFramework=".NETStandard2.0">
-        <dependency id="System.Security.Principal.Windows" version="5.0.0" />
-		<dependency id="System.Security.Cryptography.Pkcs" version="8.0.0" />
-		<dependency id="System.Security.Cryptography.X509Certificates" version="4.3.2" />
-      </group>
-    </dependencies>
+	  <dependencies>
+		  <group targetFramework=".NETStandard2.0">
+			  <dependency id="System.Security.Principal.Windows" version="7.0.0" />
+			  <dependency id="System.Security.Cryptography.Pkcs" version="9.0.0" />
+			  <dependency id="System.Security.Cryptography.X509Certificates" version="7.0.0" />
+		  </group>
+	  </dependencies>
   </metadata>
   <files>
     <file src="..\Release\launcher.dll" target="lib\netstandard2.0" />


### PR DESCRIPTION
- Updated target frameworks to net9.0 and net9.0-windows7.0 in LauncherTest.csproj and launcherTests.csproj. 
- Upgraded MSTest.TestAdapter and MSTest.TestFramework to 3.6.3 in launcherTests.csproj. 
- Updated System.Security.Cryptography.Pkcs and System.Text.Json to 9.0.0 in Launcher.csproj.